### PR TITLE
Upstream merge and fixes (2025-11-05)

### DIFF
--- a/.github/workflows/vagrant-up.yml
+++ b/.github/workflows/vagrant-up.yml
@@ -102,3 +102,8 @@ jobs:
         with:
           body: "The VM archive can not be directly added to this release because of the size limitation of 2GB per file. Please download the splitted ZIP archive and extract it manually."
           files: emoflon-vm.z03
+      - name: release emoflon-vm (5)
+        uses: softprops/action-gh-release@v2
+        with:
+          body: "The VM archive can not be directly added to this release because of the size limitation of 2GB per file. Please download the splitted ZIP archive and extract it manually."
+          files: emoflon-vm.z04

--- a/.github/workflows/vagrant-up.yml
+++ b/.github/workflows/vagrant-up.yml
@@ -62,7 +62,7 @@ jobs:
         tar -cvf emoflon.ova emoflon.ovf emoflon-disk001.vmdk
         rm -rf emoflon.ovf emoflon-disk001.vmdk
     - name: upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: emoflon-ova
         path: emoflon.ova

--- a/.github/workflows/vagrant-up.yml
+++ b/.github/workflows/vagrant-up.yml
@@ -75,7 +75,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/') && github.event_name != 'schedule'
     steps:
       - name: collect artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
       - name: create splitted ZIP archive
         run: |
           sudo apt-get install -yq zip

--- a/.github/workflows/vagrant-up.yml
+++ b/.github/workflows/vagrant-up.yml
@@ -79,7 +79,7 @@ jobs:
       - name: create splitted ZIP archive
         run: |
           sudo apt-get install -yq zip
-          zip -r -s 1990m emoflon-vm.zip emoflon-ova/emoflon.ova
+          zip -r -s 1990m emoflon-vm.zip emoflon.ova
       # Due to a bug in the release action, we have to upload all artifacts step-by-step
       # https://github.com/softprops/action-gh-release/issues/243
       - name: release emoflon-vm (1)

--- a/.github/workflows/vagrant-up.yml
+++ b/.github/workflows/vagrant-up.yml
@@ -44,7 +44,7 @@ jobs:
         rm -rf ./* || true
         rm -rf ./.??* || true
         ls -la ./
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: show Vagrant version
       run: vagrant --version
     - name: run vagrant up

--- a/.github/workflows/vagrant-up.yml
+++ b/.github/workflows/vagrant-up.yml
@@ -70,7 +70,7 @@ jobs:
   # Create a release if running on tag
   create-release:
     needs: [vagrant-provision]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Only run on pushed tags (and explicitely ignore scheduled runs)
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/') && github.event_name != 'schedule'
     steps:

--- a/.github/workflows/vagrant-up.yml
+++ b/.github/workflows/vagrant-up.yml
@@ -36,7 +36,7 @@ jobs:
     - name: clean up old Vagrant artifacts
       run: | 
         vagrant destroy emoflon || true
-        vagrant box remove gusztavvargadr/xubuntu-desktop-2204-lts || true
+        vagrant box remove gusztavvargadr/xubuntu-desktop-2404-lts || true
     # https://stackoverflow.com/a/71346341
     - name: clean up old GitHub Actions runner build folder
       run: |

--- a/.github/workflows/vagrant-up.yml
+++ b/.github/workflows/vagrant-up.yml
@@ -75,7 +75,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/') && github.event_name != 'schedule'
     steps:
       - name: collect artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
       - name: create splitted ZIP archive
         run: |
           sudo apt-get install -yq zip

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is used to automatically build an [eMoflon](https://emoflon.org)
 ## Packages/Configuration
 
 - [Ubuntu 24.04](https://app.vagrantup.com/gusztavvargadr/boxes/xubuntu-desktop-2404-lts)
-- [OpenJDK 17](https://openjdk.org/projects/jdk/17/)
+- [OpenJDK 21](https://openjdk.org/projects/jdk/21/)
 - [Graphviz](https://graphviz.org/)
 - [eMoflon IBeX Eclipse build](https://github.com/eMoflon/emoflon-ibex-eclipse-build) (variant: *eclipse-emoflon-linux-user*)
 

--- a/README.md
+++ b/README.md
@@ -64,4 +64,6 @@ Required packages (at least):
 - `VirtualBox`
 - `vagrant`
 
+There is a [script](./runner-setup.sh) available to install the necessary packages.
+
 **Please keep in mind that your runner (VM) needs the virtualization flag enabled and at least 10 GB of RAM!**

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is used to automatically build an [eMoflon](https://emoflon.org)
 
 ## Packages/Configuration
 
-- [Ubuntu 22.04](https://app.vagrantup.com/gusztavvargadr/boxes/xubuntu-desktop-2204-lts)
+- [Ubuntu 24.04](https://app.vagrantup.com/gusztavvargadr/boxes/xubuntu-desktop-2404-lts)
 - [OpenJDK 17](https://openjdk.org/projects/jdk/17/)
 - [Graphviz](https://graphviz.org/)
 - [eMoflon IBeX Eclipse build](https://github.com/eMoflon/emoflon-ibex-eclipse-build) (variant: *eclipse-emoflon-linux-user*)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 token = ENV["GITHUB_TOKEN"]
 
 Vagrant.configure("2") do |config|
-    config.vm.box = "gusztavvargadr/xubuntu-desktop-2204-lts"
+    config.vm.box = "gusztavvargadr/xubuntu-desktop-2404-lts"
     config.vm.define 'emoflon'
     config.vm.provider :virtualbox do |vb|
         vb.name = "emoflon"

--- a/prov.sh
+++ b/prov.sh
@@ -146,6 +146,15 @@ sudo apt-get update
 sudo apt-get install -y neo4j
 sudo systemctl enable neo4j
 
+# Install OpenJDK 11 (necessary for Neo4J)
+# https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
+sudo wget -O /opt/openjdk-11.0.2_linux-x64_bin.tar.gz https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
+sudo tar -zxvf /opt/openjdk-11.0.2_linux-x64_bin.tar.gz -C /opt
+sudo rm /opt/openjdk-11.0.2_linux-x64_bin.tar.gz
+# Adapt Neo4J's systemd service file to use the old(er) JVM instead of the system's one
+sudo sed -i 's/Environment=\"NEO4J_CONF=\/etc\/neo4j\"\ \"NEO4J_HOME=\/var\/lib\/neo4j\"/Environment=\"NEO4J_CONF=\/etc\/neo4j\"\ \"NEO4J_HOME=\/var\/lib\/neo4j\"\ \"JAVA_HOME=\/opt\/jdk-11.0.2\"/' /usr/lib/systemd/system/neo4j.service
+sudo systemctl daemon-reload
+
 log "Clean-up"
 sudo apt-get remove -yq \
         libreoffice-* \

--- a/prov.sh
+++ b/prov.sh
@@ -112,6 +112,13 @@ Icon=web-browser
 
 chmod u+x /home/vagrant/Desktop/*.desktop
 
+sudo mv /home/vagrant/Desktop/*.desktop /usr/share/xubuntu/applications/
+sudo ln -s /usr/share/xubuntu/applications/emoflon-app.desktop
+sudo ln -s /usr/share/xubuntu/applications/emoflon-website.desktop
+sudo ln -s /usr/share/xubuntu/applications/emoflon-tutorial.desktop
+sudo ln -s /usr/share/xubuntu/applications/emoflon-tests.desktop
+
+# Clean up
 log "Clean-up"
 sudo apt-get remove -yq \
         libreoffice-* \

--- a/prov.sh
+++ b/prov.sh
@@ -29,9 +29,9 @@ log "Installing updates."
 sudo apt-get update
 sudo apt-get upgrade -y
 
-# Java/JDK17
+# Java/JDK21
 log "Installing OpenJDK."
-sudo apt-get install -y openjdk-17-jdk
+sudo apt-get install -y openjdk-21-jdk
 #java --version
 
 # Packages for building a new kernel

--- a/prov.sh
+++ b/prov.sh
@@ -113,10 +113,10 @@ Icon=web-browser
 chmod u+x /home/vagrant/Desktop/*.desktop
 
 sudo mv /home/vagrant/Desktop/*.desktop /usr/share/xubuntu/applications/
-sudo ln -s /usr/share/xubuntu/applications/emoflon-app.desktop
-sudo ln -s /usr/share/xubuntu/applications/emoflon-website.desktop
-sudo ln -s /usr/share/xubuntu/applications/emoflon-tutorial.desktop
-sudo ln -s /usr/share/xubuntu/applications/emoflon-tests.desktop
+sudo ln -s /usr/share/xubuntu/applications/emoflon-app.desktop /home/vagrant/Desktop/emoflon-app.desktop
+sudo ln -s /usr/share/xubuntu/applications/emoflon-website.desktop /home/vagrant/Desktop/emoflon-website.desktop
+sudo ln -s /usr/share/xubuntu/applications/emoflon-tutorial.desktop /home/vagrant/Desktop/emoflon-tutorial.desktop
+sudo ln -s /usr/share/xubuntu/applications/emoflon-tests.desktop /home/vagrant/Desktop/emoflon-tests.desktop
 
 # Clean up
 log "Clean-up"

--- a/prov.sh
+++ b/prov.sh
@@ -118,6 +118,15 @@ sudo ln -s /usr/share/xubuntu/applications/emoflon-website.desktop /home/vagrant
 sudo ln -s /usr/share/xubuntu/applications/emoflon-tutorial.desktop /home/vagrant/Desktop/emoflon-tutorial.desktop
 sudo ln -s /usr/share/xubuntu/applications/emoflon-tests.desktop /home/vagrant/Desktop/emoflon-tests.desktop
 
+# Install additional CLI tools
+log "Install additional CLI tools."
+sudo apt-get install -yq \
+        git \
+        ncdu \
+        htop \
+        tmux \
+        rsync
+
 # Clean up
 log "Clean-up"
 sudo apt-get remove -yq \

--- a/prov.sh
+++ b/prov.sh
@@ -27,7 +27,7 @@ log "Start provisioning."
 # Updates
 log "Installing updates."
 sudo apt-get update
-sudo apt-get upgrade -y
+sudo apt-get dist-upgrade -y
 
 # Java/JDK21
 log "Installing OpenJDK."

--- a/runner-setup.sh
+++ b/runner-setup.sh
@@ -6,7 +6,7 @@ USERNAME=maxkratz
 
 # utilities + sudo
 apt-get update
-apt-get install -yq sudo tmux htop wget grep sed gpg unzip tar
+apt-get install -yq sudo tmux htop wget grep sed gpg unzip tar curl
 /sbin/adduser $USERNAME sudo
 
 # VirtualBox
@@ -16,7 +16,11 @@ echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle_vbox_2016.gpg] http:/
 apt-get update
 apt-get install -yq virtualbox-7.0
 
+usermod -a -G vboxusers $USERNAME
+
 # Vagrant
-apt-get install -yq vagrant
+wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
+apt-get update && apt-get install -yq vagrant
 
 echo "=> Prerequisites installed. Ready for GitHub Actions runner installation."

--- a/runner-setup.sh
+++ b/runner-setup.sh
@@ -10,17 +10,28 @@ apt-get install -yq sudo tmux htop wget grep sed gpg unzip tar curl
 /sbin/adduser $USERNAME sudo
 
 # VirtualBox
+# https://linuxiac.com/how-to-install-virtualbox-on-debian-13-trixie/
 wget -O- -q https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --dearmour -o /usr/share/keyrings/oracle_vbox_2016.gpg
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle_vbox_2016.gpg] http://download.virtualbox.org/virtualbox/debian bookworm contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle_vbox_2016.gpg] http://download.virtualbox.org/virtualbox/debian trixie contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
 
 apt-get update
-apt-get install -yq virtualbox-7.0
+apt-get install -yq virtualbox-7.2
 
 usermod -a -G vboxusers $USERNAME
 
 # Vagrant
-wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
-apt-get update && apt-get install -yq vagrant
+# https://developer.hashicorp.com/vagrant/install#linux
+wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(grep -oP '(?<=UBUNTU_CODENAME=).*' /etc/os-release || lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+sudo apt update && sudo apt install vagrant
+
+# Disable KVM
+# https://superuser.com/a/1874448
+modprobe -r kvm_intel
+modprobe -r kvm_amd
+cat > /etc/modprobe.d/blacklist.conf<< EOF
+blacklist kvm_intel
+blacklist kvm_amd
+EOF
 
 echo "=> Prerequisites installed. Ready for GitHub Actions runner installation."


### PR DESCRIPTION
- Upgrades the base OS to Xubuntu 24.04: Closes #8.
- Integrates upstream changes (CLI tools): Closes #9.
- Integrates upstream change (runner setup script fixes): Closes #10.
- Updates OpenJDK to v21: Closes #11.
- Updates the GitHub Action runner image to Ubuntu 22.04: Closes #12.

---

- Updates various used GitHub Actions to newer/latest version.
- Fixes a bug after newer GitHub Action versions that affected OVA file access.
- Adds an installation routine for Eclipse Temurin JDK v11 (since it is required by Neo4J v4.2).